### PR TITLE
make sure the color value fits into 3 bytes

### DIFF
--- a/altium.py
+++ b/altium.py
@@ -1246,7 +1246,7 @@ class render:
 def colour(obj, property="COLOR"):
     '''Convert a TColor property value to a fractional RGB tuple'''
     c = obj.get_int(property)
-    return (x / 0xFF for x in int(c).to_bytes(3, "little"))
+    return (x / 0xFF for x in int(c & 0xFFFFFF).to_bytes(3, "little"))
 
 def font_name(id):
     '''Convert Altium font number to text name for renderer'''


### PR DESCRIPTION
I got an integer overflow because the color value did not fit into 3 bytes. The result looks good and has no visible color distortions. This does not change the color conversion behavior but simply enforces it and enables the conversion of schematics with *odd* color values.