### PR TITLE
Drawing of sheet entries

### DIFF
--- a/altium.py
+++ b/altium.py
@@ -837,6 +837,11 @@ class render:
     
     @_setitem(handlers, Record.SHEET_ENTRY) # id=16
     def handle_sheetport(self, objects, obj):
+        for property in (
+            "OWNERPARTID", "INDEXINSHEET", "ARROWKIND", "STYLE", "TEXTSTYLE"
+        ):
+            obj.get(property)
+            
         if self.last_sheet_symbol:
             with self.renderer.view(offset=get_location(self.last_sheet_symbol)) as view:
                 kw =  dict()
@@ -886,9 +891,9 @@ class render:
                 pointsx = tuple((x[0]*shape_x_factor+px, x[1]*shape_y_factor+py) for x in shape)
         
                 view.text(obj.get("NAME").decode("ascii"),
-                    colour=colour(obj),
+                    colour=colour(obj,"TEXTCOLOR"),
                     offset=(px,py),
-                    font=font_name(obj.get_int("FONTID")),
+                    font=font_name(obj.get_int("TEXTFONTID")),
                 **kw)
                 
                 areacolor = colour(obj, "AREACOLOR")
@@ -896,7 +901,7 @@ class render:
                     areacolor = (0.84, 0.89, 1)
                 
                 view.polygon(pointsx,
-                    outline=(0,0,0),
+                    outline=colour(obj),
                     width=1,
                     fill=areacolor
                 )

--- a/format.md
+++ b/format.md
@@ -391,7 +391,10 @@ circ_angle = atan2( RADIUS * sin(angle), SECONDARYRADIUS * cos(angle) )
 * `|SYMBOLTYPE=Normal`: Optional
 
 ### Sheet entry ###
-Child of [Sheet symbol](#sheet-symbol)
+Child of [Sheet symbol](#sheet-symbol). In SchDoc files you will first see a RECORD=15 which defines a sheet symbol. 
+That record is directly followed by multiple RECORD=16 entries which define the sheet entries for the previously defined sheet symbol.
+Actually there is no other way to determine the parent-child relation. 
+
 `|RECORD=16`: Sheet entries of boxes on a top-level schematic. Corresponds to a port object inside the sheet.
 * `|AREACOLOR=8454143|ARROWKIND=Block & Triangle|COLOR=128`
 * `|DISTANCEFROMTOP` ([integer]): Distance from top-left coordinate. If SIDE==0/1 Y-Coordinate, else X-Coordinate in x10 units. DISTANCEFROMTOP=10 ==> 100 in Altium.


### PR DESCRIPTION
Added drawing of sheet entries. Actually all signal flow directions (in, out, bidi, unspecified) and all symbol directions (upper, lower, left, right edge) are supported. Also added more documentation for sheet entries.