### PR TITLE
Fix import errors on Python version >= 3.10

### DIFF
--- a/vector/base.py
+++ b/vector/base.py
@@ -1,6 +1,10 @@
 import operator
 from contextlib import contextmanager
-from collections import Iterable
+try:
+    # since python 3.10
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 class View:
     def draw(self, object, offset=None, **kw):

--- a/vector/svg.py
+++ b/vector/svg.py
@@ -2,7 +2,11 @@ from xml.sax.saxutils import XMLGenerator
 from contextlib import contextmanager
 from . import base
 from math import sin, cos, radians
-from collections import Iterable
+try:
+    # since python 3.10
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 from urllib.parse import urlunparse, ParseResult
 import operator
 from textwrap import TextWrapper


### PR DESCRIPTION
Iterable was removed from collections in Python 3.10.